### PR TITLE
Replace Bitnami Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ components:
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | Modify how DNS records are synchronized between sources and providers (options: sync, upsert-only) | `string` | `"sync"` | no |
-| <a name="input_publish_internal_services"></a> [publish\_internal\_services](#input\_publish\_internal\_services) | Allow external-dns to publish DNS records for ClusterIP services | `bool` | `true` | no |
+
 | <a name="input_rbac_enabled"></a> [rbac\_enabled](#input\_rbac\_enabled) | Service Account for pods. | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region. | `string` | n/a | yes |

--- a/README.yaml
+++ b/README.yaml
@@ -3,8 +3,8 @@ name: "aws-eks-external-dns"
 github_repo: "cloudposse-terraform-components/aws-eks-external-dns"
 # Short description of this project
 description: |-
-  This component creates a Helm deployment for [external-dns](https://github.com/bitnami/bitnami-docker-external-dns) on a
-  Kubernetes cluster. [external-dns](https://github.com/bitnami/bitnami-docker-external-dns) is a Kubernetes addon that
+  This component creates a Helm deployment for [external-dns](https://github.com/kubernetes-sigs/external-dns) on a
+  Kubernetes cluster. [external-dns](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes addon that
   configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 
 usage: |-
@@ -28,8 +28,8 @@ usage: |-
           enabled: true
           name: external-dns
           chart: external-dns
-          chart_repository: https://charts.bitnami.com/bitnami
-          chart_version: "6.33.0"
+          chart_repository: https://kubernetes-sigs.github.io/external-dns/
+          chart_version: "1.18.0"
           create_namespace: true
           kubernetes_namespace: external-dns
           resources:
@@ -43,13 +43,15 @@ usage: |-
           # For example, when using blue-green deployment pattern to update EKS cluster.
           txt_prefix: ""
           # You can use `chart_values` to set any other chart options. Treat `chart_values` as the root of the doc.
-          # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/bitnami/external-dns
+          # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/external-dns/external-dns
           #
           # # For example
           # ---
           # chart_values:
-          #   aws:
-          #     batchChangeSize: 1000
+          #   provider:
+          #     name: aws
+          #   extraArgs:
+          #     - --aws-batch-change-size=1000
           chart_values: {}
           # Extra hosted zones to lookup and support by component name
           dns_components:
@@ -65,11 +67,11 @@ usage: |-
 
 references:
   - name: external-dns (Artifact Hub)
-    url: https://artifacthub.io/packages/helm/bitnami/external-dns
-    description: Helm chart for ExternalDNS by Bitnami
-  - name: ExternalDNS (Bitnami Docker)
-    url: https://github.com/bitnami/bitnami-docker-external-dns
-    description: ExternalDNS addon container image and docs by Bitnami
+    url: https://artifacthub.io/packages/helm/external-dns/external-dns
+    description: Helm chart for ExternalDNS by Kubernetes SIGs
+  - name: ExternalDNS (GitHub)
+    url: https://github.com/kubernetes-sigs/external-dns
+    description: ExternalDNS addon source code and documentation
 tags:
   - component/eks/external-dns
   - layer/eks

--- a/src/README.md
+++ b/src/README.md
@@ -8,8 +8,8 @@ tags:
 
 # Component: `eks-external-dns`
 
-This component creates a Helm deployment for [external-dns](https://github.com/bitnami/bitnami-docker-external-dns) on a
-Kubernetes cluster. [external-dns](https://github.com/bitnami/bitnami-docker-external-dns) is a Kubernetes addon that
+This component creates a Helm deployment for [external-dns](https://github.com/kubernetes-sigs/external-dns) on a
+Kubernetes cluster. [external-dns](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes addon that
 configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 ## Usage
 
@@ -33,8 +33,8 @@ components:
         enabled: true
         name: external-dns
         chart: external-dns
-        chart_repository: https://charts.bitnami.com/bitnami
-        chart_version: "6.33.0"
+        chart_repository: https://kubernetes-sigs.github.io/external-dns/
+        chart_version: "1.18.0"
         create_namespace: true
         kubernetes_namespace: external-dns
         resources:
@@ -48,13 +48,15 @@ components:
         # For example, when using blue-green deployment pattern to update EKS cluster.
         txt_prefix: ""
         # You can use `chart_values` to set any other chart options. Treat `chart_values` as the root of the doc.
-        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/bitnami/external-dns
+        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/external-dns/external-dns
         #
         # # For example
         # ---
         # chart_values:
-        #   aws:
-        #     batchChangeSize: 1000
+        #   provider:
+        #     name: aws
+        #   extraArgs:
+        #     - --aws-batch-change-size=1000
         chart_values: {}
         # Extra hosted zones to lookup and support by component name
         dns_components:
@@ -151,7 +153,7 @@ components:
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | Modify how DNS records are synchronized between sources and providers (options: sync, upsert-only) | `string` | `"sync"` | no |
-| <a name="input_publish_internal_services"></a> [publish\_internal\_services](#input\_publish\_internal\_services) | Allow external-dns to publish DNS records for ClusterIP services | `bool` | `true` | no |
+
 | <a name="input_rbac_enabled"></a> [rbac\_enabled](#input\_rbac\_enabled) | Service Account for pods. | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region. | `string` | n/a | yes |
@@ -175,12 +177,11 @@ components:
 ## References
 
 
-- [external-dns (Artifact Hub)](https://artifacthub.io/packages/helm/bitnami/external-dns) - Helm chart for ExternalDNS by Bitnami
+- [external-dns (Artifact Hub)](https://artifacthub.io/packages/helm/external-dns/external-dns) - Helm chart for ExternalDNS by Kubernetes SIGs
 
-- [ExternalDNS (Bitnami Docker)](https://github.com/bitnami/bitnami-docker-external-dns) - ExternalDNS addon container image and docs by Bitnami
+- [ExternalDNS (GitHub)](https://github.com/kubernetes-sigs/external-dns) - ExternalDNS addon source code and documentation
 
 
 
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-external-dns&utm_content=)
-

--- a/src/main.tf
+++ b/src/main.tf
@@ -57,7 +57,7 @@ module "external_dns" {
       ]
 
       effect    = "Allow"
-      resources = formatlist("arn:${join("", data.aws_partition.current.*.partition)}:route53:::hostedzone/%s", local.zone_ids)
+      resources = formatlist("arn:${data.aws_partition.current[0].partition}:route53:::hostedzone/%s", local.zone_ids)
     },
     {
       sid = "GrantListHostedZonesListResourceRecordSets"
@@ -96,15 +96,14 @@ module "external_dns" {
     }) : "",
     # external-dns-specific values
     yamlencode({
-      aws = {
-        region = var.region
+      provider = {
+        name = "aws"
       }
-      policy                  = var.policy
-      publishInternalServices = var.publish_internal_services
-      txtOwnerId              = local.txt_owner
-      txtPrefix               = local.txt_prefix
-      sources                 = local.sources
-      domainFilters           = local.zone_names
+      policy        = var.policy
+      txtOwnerId    = local.txt_owner
+      txtPrefix     = local.txt_prefix
+      sources       = local.sources
+      domainFilters = local.zone_names
     }),
     # hardcoded values
     file("${path.module}/resources/values.yaml"),

--- a/src/main.tf
+++ b/src/main.tf
@@ -24,6 +24,7 @@ data "aws_partition" "current" {
 }
 
 module "external_dns" {
+  count   = local.enabled ? 1 : 0
   source  = "cloudposse/helm-release/aws"
   version = "0.10.1"
 

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,4 +1,4 @@
 output "metadata" {
-  value       = module.external_dns.metadata
+  value       = local.enabled ? module.external_dns[0].metadata : null
   description = "Block status of the deployed release"
 }

--- a/src/resources/values.yaml
+++ b/src/resources/values.yaml
@@ -1,10 +1,5 @@
-aws:
-  evaluateTargetHealth: false
-rbac:
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ## RBAC API version
-  apiVersion: v1
-  ## Podsecuritypolicy
-  pspEnabled: false
-provider: aws
+# AWS provider configuration for external-dns
+# The official external-dns chart uses provider.name instead of the provider field
+# AWS-specific settings are configured via extraArgs
+extraArgs:
+  - --aws-evaluate-target-health=false

--- a/src/resources/values.yaml
+++ b/src/resources/values.yaml
@@ -2,4 +2,5 @@
 # The official external-dns chart uses provider.name instead of the provider field
 # AWS-specific settings are configured via extraArgs
 extraArgs:
-  - --aws-evaluate-target-health=false
+  # Add AWS-specific arguments here if needed
+  # Example: --aws-batch-change-size=1000

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -142,11 +142,7 @@ variable "dns_components" {
   default     = []
 }
 
-variable "publish_internal_services" {
-  type        = bool
-  description = "Allow external-dns to publish DNS records for ClusterIP services"
-  default     = true
-}
+
 
 variable "policy" {
   type        = string

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -2,22 +2,23 @@ package test
 
 import (
 	"context"
-	"testing"
 	"fmt"
 	"strings"
+	"testing"
 	"time"
+
 	"github.com/cloudposse/test-helpers/pkg/atmos"
-	"github.com/cloudposse/test-helpers/pkg/helm"
-	awsHelper "github.com/cloudposse/test-helpers/pkg/aws"
 	helper "github.com/cloudposse/test-helpers/pkg/atmos/component-helper"
+	awsHelper "github.com/cloudposse/test-helpers/pkg/aws"
+	"github.com/cloudposse/test-helpers/pkg/helm"
 	awsTerratest "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/client-go/dynamic"
 )
@@ -65,15 +66,14 @@ func (s *ComponentSuite) TestBasic() {
 
 	metadata := metadataArray[0]
 
-	assert.Equal(s.T(), metadata.AppVersion, "0.14.0")
+	assert.Equal(s.T(), metadata.AppVersion, "0.18.0")
 	assert.Equal(s.T(), metadata.Chart, "external-dns")
 	assert.NotNil(s.T(), metadata.FirstDeployed)
 	assert.NotNil(s.T(), metadata.LastDeployed)
 	assert.Equal(s.T(), metadata.Name, "external-dns")
 	assert.Equal(s.T(), metadata.Namespace, namespace)
 	assert.NotNil(s.T(), metadata.Values)
-	assert.Equal(s.T(), metadata.Version, "6.33.0")
-
+	assert.Equal(s.T(), metadata.Version, "1.18.0")
 
 	config, err := awsHelper.NewK8SClientConfig(cluster)
 	assert.NoError(s.T(), err)
@@ -97,13 +97,13 @@ func (s *ComponentSuite) TestBasic() {
 			"apiVersion": "externaldns.k8s.io/v1alpha1",
 			"kind":       "DNSEndpoint",
 			"metadata": map[string]interface{}{
-				"name":	dnsEndpointName,
+				"name":      dnsEndpointName,
 				"namespace": namespace,
 			},
 			"spec": map[string]interface{}{
 				"endpoints": []interface{}{
 					map[string]interface{}{
-						"dnsName": dnsRecordHostName,
+						"dnsName":    dnsRecordHostName,
 						"recordTTL":  300,
 						"recordType": "A",
 						"targets": []interface{}{

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -10,8 +10,8 @@ components:
         dns_gbl_primary_environment_name: ue2
         name: external-dns
         chart: external-dns
-        chart_repository: https://charts.bitnami.com/bitnami
-        chart_version: "6.33.0"
+        chart_repository: https://kubernetes-sigs.github.io/external-dns/
+        chart_version: "1.18.0"
         create_namespace: true
         kubernetes_namespace: external-dns
         resources:
@@ -25,16 +25,18 @@ components:
         # For example, when using blue-green deployment pattern to update EKS cluster.
         txt_prefix: ""
         # You can use `chart_values` to set any other chart options. Treat `chart_values` as the root of the doc.
-        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/bitnami/external-dns
+        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/external-dns/external-dns
         #
         # # For example
         # ---
         # chart_values:
-        #   aws:
-        #     batchChangeSize: 1000
+        #   provider:
+        #     name: aws
+        #   extraArgs:
+        #     - --aws-batch-change-size=1000
         chart_values:
-          crd:
-            create: true
+          provider:
+            name: aws
           sources:
             - crd
             - service

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -10,8 +10,8 @@ components:
         dns_gbl_primary_environment_name: ue2
         name: external-dns
         chart: external-dns
-        chart_repository: https://charts.bitnami.com/bitnami
-        chart_version: "6.33.0"
+        chart_repository: https://kubernetes-sigs.github.io/external-dns/
+        chart_version: "1.18.0"
         create_namespace: true
         kubernetes_namespace: external-dns
         resources:
@@ -25,13 +25,15 @@ components:
         # For example, when using blue-green deployment pattern to update EKS cluster.
         txt_prefix: ""
         # You can use `chart_values` to set any other chart options. Treat `chart_values` as the root of the doc.
-        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/bitnami/external-dns
+        # See documentation for latest chart version and list of chart_values: https://artifacthub.io/packages/helm/external-dns/external-dns
         #
         # # For example
         # ---
         # chart_values:
-        #   aws:
-        #     batchChangeSize: 1000
+        #   provider:
+        #     name: aws
+        #   extraArgs:
+        #     - --aws-batch-change-size=1000
         chart_values: {}
         # Extra hosted zones to lookup and support by component name
         dns_components: []


### PR DESCRIPTION
## what

- Migrated from deprecated Bitnami external-dns chart to official Kubernetes SIGs external-dns chart
- Updated chart repository from https://charts.bitnami.com/bitnami to https://kubernetes-sigs.github.io/external-dns/
- Modified configuration structure to match official chart format (e.g., provider.name: aws instead of provider: aws)
- Removed unused publish_internal_services variable
- Fixed deprecated Terraform index syntax (.* to [0])
- Updated documentation to reflect new chart structure and examples

## why

- Bitnami external-dns chart is deprecated and no longer maintained
- Official Kubernetes SIGs chart provides active development and security updates
- Ensures long-term maintainability and support for the component
- Fixes TFLint warnings for deprecated syntax and unused variables
- Maintains all existing functionality while using actively supported chart

## ref
- DEV-3586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Switched docs and examples to the official Kubernetes SIGs external-dns chart and updated links.
  - Removed publish_internal_services from docs and added rbac_enabled (default: true); updated examples to use provider.name and extraArgs.

- Chores
  - Migrated chart source/version to upstream external-dns (1.18.0) and aligned defaults.
  - Component/module creation and outputs now respect the enabled flag.

- Refactor
  - AWS config moved to provider/extraArgs style; removed legacy aws/rbac blocks.

- Tests
  - Updated fixtures and test expectations to match new repo/version and config format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->